### PR TITLE
Django 4 compatibility

### DIFF
--- a/django_zxcvbn_password_validator/translate_zxcvbn_text.py
+++ b/django_zxcvbn_password_validator/translate_zxcvbn_text.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 LOGGER = logging.getLogger(__file__)
 

--- a/django_zxcvbn_password_validator/translate_zxcvbn_text.py
+++ b/django_zxcvbn_password_validator/translate_zxcvbn_text.py
@@ -1,6 +1,9 @@
 import logging
 
-from django.utils.translation import gettext_lazy as _
+try:
+  from django.utils.translation import gettext_lazy as _
+except ImportError:
+  from django.utils.translation import ugettext_lazy as _
 
 LOGGER = logging.getLogger(__file__)
 

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from zxcvbn import zxcvbn
 
 from django_zxcvbn_password_validator.settings import DEFAULT_MINIMAL_STRENGTH

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.utils.translation import gettext_lazy as _
+try:
+  from django.utils.translation import gettext_lazy as _
+except ImportError:
+  from django.utils.translation import ugettext_lazy as _
 from zxcvbn import zxcvbn
 
 from django_zxcvbn_password_validator.settings import DEFAULT_MINIMAL_STRENGTH


### PR DESCRIPTION
When trying to use this library in Django 4 an exception is thrown:

```
ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation'
```

Related to feature removal in Django 4:
https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() are removed.

Deprecated in Django 3:
https://docs.djangoproject.com/en/4.0/releases/3.0/#id3

> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() are deprecated in favor of the functions that they’re aliases for: django.utils.translation.gettext(), gettext_lazy(), gettext_noop(), ngettext(), and ngettext_lazy().