### PR TITLE
chore: bump minimal Python version to 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django-version: ["<4", "<5", "<6"]
         exclude:
           - python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { text = "MIT" }
 authors = [
   { email = "pierre.sassoulas@gmail.com", name = "Pierre SASSOULAS" },
 ]
-requires-python = ">=3.7.0"
+requires-python = ">=3.9.0"
 
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -33,8 +33,6 @@ classifiers = [
   "Natural Language :: Portuguese (Brazilian)",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This is the oldest one currently supported upstream and makes it possible to resolve the dependencies because pylint-django is not installable on Python 3.7.
