### PR TITLE
fix(validation): catch ValueError from zxcvbn

### DIFF
--- a/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
@@ -87,6 +87,14 @@ class ZxcvbnPasswordValidatorTest(TestCase):
         self.assertIsNone(self.validator.validate("123"))
         self.assertIsNone(self.validator.validate("godzilla"))
 
+    def test_long_password(self):
+        self.validator = ZxcvbnPasswordValidator()
+        with self.assertRaises(ValidationError) as error:
+            self.validator.validate("x" * 80)
+        self.assertIn(
+            "Your password exceeds the maximal length", error.exception.messages[0]
+        )
+
     @override_settings(PASSWORD_MINIMAL_STRENGTH=None)
     @override_settings(PASSWORD_MINIMAL_STRENTH=0)
     def test_compatibility_with_old_settings(self):

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -63,7 +63,13 @@ class ZxcvbnPasswordValidator:
         if user:
             for value in user.__dict__.values():
                 user_inputs.append(value)
-        results = self.zxcvbn_implementation(password, user_inputs=user_inputs)
+        try:
+            results = self.zxcvbn_implementation(password, user_inputs=user_inputs)
+        except ValueError as error:
+            # zxcvbn raises ValueError only if the password is too long.
+            raise ValidationError(
+                _("Your password exceeds the maximal length of 72 characters.")
+            ) from error
         password_strength = results["score"]
         if password_strength < self.password_minimal_strength:
             crack_time = results["crack_times_display"]


### PR DESCRIPTION
It is triggered when the password is too long.

Fixes #123