### PR TITLE
Feed zxcvbn only meaningful user string attributes

### DIFF
--- a/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
@@ -80,6 +80,37 @@ class ZxcvbnPasswordValidatorTest(TestCase):
             self.validator.validate("testclient@example.com", user=user)
         self.assertIn("Your password is too guessable", error.exception.messages[0])
 
+    def test_user_inputs_only_meaningful_strings(self):
+        """Only string user attributes are fed to zxcvbn.
+
+        The hashed password, Django's private '_state', and non-string values
+        (ids, booleans, datetimes) must never be passed as user_inputs.
+        """
+        captured = {}
+
+        def fake_zxcvbn(_password, user_inputs=None):
+            captured["user_inputs"] = user_inputs
+            return {
+                "score": 4,
+                "crack_times_seconds": {"offline_slow_hashing_1e4_per_second": 0},
+                "feedback": {"warning": "", "suggestions": []},
+            }
+
+        validator = ZxcvbnPasswordValidator(zxcvbn_implementation=fake_zxcvbn)
+        user = User.objects.create(
+            username="testclient",
+            first_name="Test",
+            last_name="Client",
+            email="testclient@example.com",
+            password="sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+        )
+        validator.validate("a-strong-enough-password", user=user)
+        user_inputs = captured["user_inputs"]
+        self.assertIn("testclient", user_inputs)
+        self.assertIn("testclient@example.com", user_inputs)
+        self.assertNotIn(user.password, user_inputs)
+        self.assertTrue(all(isinstance(value, str) for value in user_inputs))
+
     @override_settings(PASSWORD_MINIMAL_STRENGTH=0)
     def test_low_strength(self):
         self.validator = ZxcvbnPasswordValidator()

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -61,8 +61,15 @@ class ZxcvbnPasswordValidator:
 
         user_inputs = []
         if user:
-            for value in user.__dict__.values():
-                user_inputs.append(value)
+            for key, value in user.__dict__.items():
+                # Only feed zxcvbn meaningful string attributes. Skip private
+                # attributes (e.g. Django's '_state'), the hashed password, and
+                # any non-string value, none of which are useful as a
+                # dictionary of terms the password should not resemble.
+                if key.startswith("_") or key == "password":
+                    continue
+                if isinstance(value, str) and value:
+                    user_inputs.append(value)
         try:
             results = self.zxcvbn_implementation(password, user_inputs=user_inputs)
         except ValueError as error:


### PR DESCRIPTION
`validate()` passed every value of `user.__dict__` as `user_inputs`, including
the hashed password, Django's private `_state` ModelState object, ids, booleans
and datetimes. Filter to non-empty string attributes and exclude private keys
and the password, so `user_inputs` is a clean list of terms the password should
not resemble (username, email, names).

A test captures what is passed to zxcvbn (via an injected implementation) and
asserts the hashed password and non-string values are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)