### PR TITLE
Add get_strength() public API for non-raising strength checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ zxcvbn that are in English only):
 
 ![Translated example](doc/french_example.png "Translated example")
 
+## Checking strength without raising
+
+`validate()` raises a `ValidationError` when a password is too weak, which is what
+Django's auth machinery expects. If you instead want to _inspect_ a password's strength
+— for example to power a live strength meter — use `get_strength()`, which never raises
+for a weak password:
+
+```python
+from django_zxcvbn_password_validator import ZxcvbnPasswordValidator
+
+strength = ZxcvbnPasswordValidator().get_strength("p@sswOrd1", user=request.user)
+# {
+#     "score": 1,                  # zxcvbn score, 0 (worst) to 4 (best)
+#     "minimal_strength": 4,       # your PASSWORD_MINIMAL_STRENGTH
+#     "acceptable": False,         # score >= minimal_strength
+#     "crack_time_seconds": 2.0,   # estimated offline crack time
+#     "crack_time_display": "2 seconds",          # the same, translated
+#     "warning": "This is similar to a commonly used password",  # translated
+#     "suggestions": ["Add another word or two. Uncommon words are better"],  # translated
+# }
+```
+
+The `warning`, `suggestions` and `crack_time_display` fields are translated to the
+active language, just like the validation errors. `get_strength()` still raises
+`ValidationError` if the password exceeds zxcvbn's maximal length.
+
 ## Compatibility
 
 Requires Django 2+ and Python 3.6+. Note that Python 3.6 and 3.7 are not tested in CI

--- a/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
@@ -111,6 +111,42 @@ class ZxcvbnPasswordValidatorTest(TestCase):
         self.assertNotIn(user.password, user_inputs)
         self.assertTrue(all(isinstance(value, str) for value in user_inputs))
 
+    @override_settings(LANGUAGE_CODE="en-us")
+    @override_settings(PASSWORD_MINIMAL_STRENGTH=2)
+    def test_get_strength_weak(self):
+        validator = ZxcvbnPasswordValidator()
+        strength = validator.get_strength("password")
+        self.assertEqual(strength["score"], 0)
+        self.assertEqual(strength["minimal_strength"], 2)
+        self.assertFalse(strength["acceptable"])
+        self.assertEqual(strength["crack_time_display"], "less than a second")
+        self.assertTrue(strength["suggestions"])
+
+    @override_settings(LANGUAGE_CODE="en-us")
+    @override_settings(PASSWORD_MINIMAL_STRENGTH=2)
+    def test_get_strength_strong(self):
+        validator = ZxcvbnPasswordValidator()
+        strength = validator.get_strength("A God, an alpha predator, Godzilla.")
+        self.assertGreaterEqual(strength["score"], 2)
+        self.assertTrue(strength["acceptable"])
+        self.assertEqual(strength["warning"], "")
+        self.assertEqual(strength["suggestions"], [])
+
+    @override_settings(LANGUAGE_CODE="fr")
+    @override_settings(PASSWORD_MINIMAL_STRENGTH=2)
+    def test_get_strength_is_translated(self):
+        validator = ZxcvbnPasswordValidator()
+        strength = validator.get_strength("g0dz1ll@")
+        self.assertIn("seconde", strength["crack_time_display"])
+        self.assertIn(
+            "C'est proche d'un mot de passe très courant", strength["warning"]
+        )
+
+    def test_get_strength_too_long(self):
+        validator = ZxcvbnPasswordValidator()
+        with self.assertRaises(ValidationError):
+            validator.get_strength("x" * 80)
+
     @override_settings(PASSWORD_MINIMAL_STRENGTH=0)
     def test_low_strength(self):
         self.validator = ZxcvbnPasswordValidator()

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -49,6 +49,58 @@ class ZxcvbnPasswordValidator:
             error_msg += f" ({self.password_minimal_strength} is not in [0,4])"
             raise ImproperlyConfigured(error_msg)
 
+    @staticmethod
+    def _get_user_inputs(user):
+        # Only feed zxcvbn meaningful string attributes. Skip private
+        # attributes (e.g. Django's '_state'), the hashed password, and any
+        # non-string value, none of which are useful as a dictionary of terms
+        # the password should not resemble.
+        user_inputs = []
+        if user:
+            for key, value in user.__dict__.items():
+                if key.startswith("_") or key == "password":
+                    continue
+                if isinstance(value, str) and value:
+                    user_inputs.append(value)
+        return user_inputs
+
+    def _run_zxcvbn(self, password, user=None):
+        try:
+            return self.zxcvbn_implementation(
+                password, user_inputs=self._get_user_inputs(user)
+            )
+        except ValueError as error:
+            # zxcvbn raises ValueError only if the password is too long.
+            raise ValidationError(
+                _("Your password exceeds the maximal length of 72 characters.")
+            ) from error
+
+    def get_strength(self, password, user=None):
+        """Return structured, translated strength information for a password.
+
+        Unlike :meth:`validate`, this never raises for a weak password, so it
+        can drive a strength meter or progressive UI. It still raises
+        ``ValidationError`` if the password exceeds zxcvbn's maximal length.
+        """
+        results = self._run_zxcvbn(password, user)
+        score = results["score"]
+        offline_time = results["crack_times_seconds"][
+            "offline_slow_hashing_1e4_per_second"
+        ]
+        warning = results["feedback"]["warning"]
+        return {
+            "score": score,
+            "minimal_strength": self.password_minimal_strength,
+            "acceptable": score >= self.password_minimal_strength,
+            "crack_time_seconds": offline_time,
+            "crack_time_display": str(translate_zxcvbn_time_estimate(offline_time)),
+            "warning": translate_zxcvbn_text(warning) if warning else "",
+            "suggestions": [
+                translate_zxcvbn_text(suggestion)
+                for suggestion in results["feedback"]["suggestions"]
+            ],
+        }
+
     def validate(self, password, user=None):
         def append_translated_feedback(old_feedbacks, feedback_type, new_feedbacks):
             if new_feedbacks:
@@ -59,24 +111,7 @@ class ZxcvbnPasswordValidator:
                         f"{feedback_type} {translate_zxcvbn_text(new_feedback)}"
                     )
 
-        user_inputs = []
-        if user:
-            for key, value in user.__dict__.items():
-                # Only feed zxcvbn meaningful string attributes. Skip private
-                # attributes (e.g. Django's '_state'), the hashed password, and
-                # any non-string value, none of which are useful as a
-                # dictionary of terms the password should not resemble.
-                if key.startswith("_") or key == "password":
-                    continue
-                if isinstance(value, str) and value:
-                    user_inputs.append(value)
-        try:
-            results = self.zxcvbn_implementation(password, user_inputs=user_inputs)
-        except ValueError as error:
-            # zxcvbn raises ValueError only if the password is too long.
-            raise ValidationError(
-                _("Your password exceeds the maximal length of 72 characters.")
-            ) from error
+        results = self._run_zxcvbn(password, user)
         password_strength = results["score"]
         if password_strength < self.password_minimal_strength:
             crack_time = results["crack_times_seconds"]


### PR DESCRIPTION
Stacked on #165.

`validate()` was the only entry point, forcing a raised `ValidationError` to
learn anything about a password. `get_strength(password, user=None)` returns a
structured, translated dict (score, acceptable, crack time, warning,
suggestions) so callers can drive a strength meter / progressive UI without
catching exceptions.

The zxcvbn invocation and `user_inputs` construction are extracted into shared
helpers so `validate()` and `get_strength()` stay in sync; `validate()`
behaviour and messages are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)