### PR TITLE
Add PASSWORD_EXTRA_DICTIONARY for project-specific weak terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ every password scoring lower than this number will be rejected:
 PASSWORD_MINIMAL_STRENGTH = 0 if DEBUG else 4
 ```
 
+You can also provide a project-specific list of terms a password should not resemble
+(your company name, product name, etc.) with `PASSWORD_EXTRA_DICTIONARY`. These are fed
+to zxcvbn on every check, in addition to the user's own attributes:
+
+```python
+PASSWORD_EXTRA_DICTIONARY = ["AcmeCorp", "RocketWidget"]
+```
+
 If the password is not strong enough, we provide errors explaining what you need to do:
 
 ![English example](doc/english_example.png "English example")

--- a/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/test_zxcvbn_password_validator.py
@@ -147,6 +147,41 @@ class ZxcvbnPasswordValidatorTest(TestCase):
         with self.assertRaises(ValidationError):
             validator.get_strength("x" * 80)
 
+    @override_settings(PASSWORD_EXTRA_DICTIONARY=["AcmeCorp", "RocketWidget"])
+    def test_extra_dictionary_is_fed_to_zxcvbn(self):
+        captured = {}
+
+        def fake_zxcvbn(_password, user_inputs=None):
+            captured["user_inputs"] = user_inputs
+            return {
+                "score": 4,
+                "crack_times_seconds": {"offline_slow_hashing_1e4_per_second": 0},
+                "feedback": {"warning": "", "suggestions": []},
+            }
+
+        validator = ZxcvbnPasswordValidator(zxcvbn_implementation=fake_zxcvbn)
+        validator.validate("some-password")
+        self.assertIn("AcmeCorp", captured["user_inputs"])
+        self.assertIn("RocketWidget", captured["user_inputs"])
+
+    @override_settings(PASSWORD_EXTRA_DICTIONARY=["AcmeCorp"])
+    @override_settings(PASSWORD_MINIMAL_STRENGTH=2)
+    def test_extra_dictionary_weakens_matching_password(self):
+        validator = ZxcvbnPasswordValidator()
+        # A brand term from the extra dictionary must be treated as guessable.
+        self.assertFalse(validator.get_strength("AcmeCorp")["acceptable"])
+
+    @override_settings(PASSWORD_EXTRA_DICTIONARY="not-a-list")
+    def test_extra_dictionary_must_be_list(self):
+        with self.assertRaises(ImproperlyConfigured) as error:
+            ZxcvbnPasswordValidator()
+        self.assertIn("PASSWORD_EXTRA_DICTIONARY must be a list", str(error.exception))
+
+    @override_settings(PASSWORD_EXTRA_DICTIONARY=[123])
+    def test_extra_dictionary_must_be_strings(self):
+        with self.assertRaises(ImproperlyConfigured):
+            ZxcvbnPasswordValidator()
+
     @override_settings(PASSWORD_MINIMAL_STRENGTH=0)
     def test_low_strength(self):
         self.validator = ZxcvbnPasswordValidator()

--- a/django_zxcvbn_password_validator/zxcvbn_password_validator.py
+++ b/django_zxcvbn_password_validator/zxcvbn_password_validator.py
@@ -31,6 +31,20 @@ class ZxcvbnPasswordValidator:
             password_minimal_strength = DEFAULT_MINIMAL_STRENGTH
         self.password_minimal_strength = password_minimal_strength
         self.__check_password_minimal_strength()
+        self.extra_dictionary = self.__get_extra_dictionary()
+
+    @staticmethod
+    def __get_extra_dictionary():
+        extra_dictionary = getattr(settings, "PASSWORD_EXTRA_DICTIONARY", None) or []
+        if not isinstance(extra_dictionary, (list, tuple)) or not all(
+            isinstance(term, str) for term in extra_dictionary
+        ):
+            raise ImproperlyConfigured(
+                "PASSWORD_EXTRA_DICTIONARY must be a list of strings (terms a "
+                "password should not resemble, e.g. your company or product "
+                f"name), not {extra_dictionary!r}."
+            )
+        return list(extra_dictionary)
 
     def __check_password_minimal_strength(self):
         error_msg = "ZxcvbnPasswordValidator need an integer between 0 and 4 "
@@ -49,13 +63,13 @@ class ZxcvbnPasswordValidator:
             error_msg += f" ({self.password_minimal_strength} is not in [0,4])"
             raise ImproperlyConfigured(error_msg)
 
-    @staticmethod
-    def _get_user_inputs(user):
-        # Only feed zxcvbn meaningful string attributes. Skip private
-        # attributes (e.g. Django's '_state'), the hashed password, and any
-        # non-string value, none of which are useful as a dictionary of terms
-        # the password should not resemble.
-        user_inputs = []
+    def _get_user_inputs(self, user):
+        # Start from the project-wide extra dictionary (e.g. company or product
+        # names), then add the user's meaningful string attributes. Skip
+        # private attributes (e.g. Django's '_state'), the hashed password, and
+        # any non-string value, none of which are useful as a dictionary of
+        # terms the password should not resemble.
+        user_inputs = list(self.extra_dictionary)
         if user:
             for key, value in user.__dict__.items():
                 if key.startswith("_") or key == "password":


### PR DESCRIPTION
Projects can declare terms a password should not resemble (company name,
product name, brand words) via the `PASSWORD_EXTRA_DICTIONARY` setting. These
are fed to zxcvbn as `user_inputs` on every check, alongside the user's own
attributes, so e.g. `AcmeCorp` is rejected as guessable. The setting is
validated as a list of strings at construction time. Documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)